### PR TITLE
alignment-writer v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # alignment-writer
 Pack/unpack [Themisto](https://github.com/algbio/themisto)
+or [Fulgor](https://github.com/jermp/fulgor)
 pseudoalignment files into/from a compact representation using the
 [BitMagic](https://github.com/tlk00/BitMagic) library.
 
@@ -22,6 +23,10 @@ pseudoalignment files into/from a compact representation using the
 - This will compile the alignment-writer executable in build/bin/.
 
 # Usage
+Default options assume that the alignment is written in the Themisto
+format. Add the `--format fulgor` toggle to read in alignments from
+Fulgor.
+
 ## Read from a file
 All calls print the results to cout.
 
@@ -43,10 +48,22 @@ first column (read_id). This is equivalent to using the
 
 ## Read from cin
 Omitting the `-f` option sets alignment-writer to read input from
-cin. This can be used to pack the output from
-[Themisto](https://github.com/algbio/themisto) without first writing it to disk
+cin. This can be used to pack the output from a pseudoaligner without first writing it to disk
 ```
 themisto pseudoalign -q query_reads.fastq -i index --temp-dir tmp | alignment-writer -n <number of reference sequences> -r <number of reads> > alignment.aln
+```
+
+## More options
+alignment-writer accepts the following flags
+```
+Usage: alignment-writer -f <input-file>
+-f	Pseudoalignment file, packed or unpacked, read from cin if not supplied.
+-d	Unpack pseudoalignment.
+-n	Number of reference sequences in the pseudoalignment (required for packing).
+-r	Number of reads in the pseudoalignment (required for packing).
+--buffer-size	Buffer size for buffered packing (default: 100000
+--format	Input file format (one of `themisto` (default), `fulgor`)
+--help	Print the help message.
 ```
 
 # File format

--- a/include/pack.hpp
+++ b/include/pack.hpp
@@ -42,11 +42,13 @@
 #include "bm64.h"
 
 namespace alignment_writer {
+enum Format { themisto };
+
 // Pack a pseudoalignment that is already in memory
 void Pack(const bm::bvector<> &bits, const size_t n_refs, const size_t n_reads, std::ostream *out);
 
 // Buffered read of a pseudoalignment from a stream and packing
-void BufferedPack(const size_t n_refs, const size_t n_reads, const size_t &buffer_size, std::istream *in, std::ostream *out);
+void BufferedPack(const Format &format, const size_t n_refs, const size_t n_reads, const size_t &buffer_size, std::istream *in, std::ostream *out);
 }
 
 #endif

--- a/include/pack.hpp
+++ b/include/pack.hpp
@@ -42,7 +42,7 @@
 #include "bm64.h"
 
 namespace alignment_writer {
-enum Format { themisto };
+enum Format { themisto, fulgor };
 
 // Pack a pseudoalignment that is already in memory
 void Pack(const bm::bvector<> &bits, const size_t n_refs, const size_t n_reads, std::ostream *out);

--- a/src/alignment_writer.cpp
+++ b/src/alignment_writer.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[]) {
     if (args.value<bool>('d')) {
 	alignment_writer::Print(in.get(), &std::cout);
     } else {
-        alignment_writer::BufferedPack(args.value<size_t>('n'), args.value<size_t>('r'), args.value<size_t>("buffer-size"), in.get(), &std::cout);
+        alignment_writer::BufferedPack(alignment_writer::themisto, args.value<size_t>('n'), args.value<size_t>('r'), args.value<size_t>("buffer-size"), in.get(), &std::cout);
     }
     if (args.value<std::string>('f').empty()) {
 	in.release(); // Release ownership of std::cout so we don't try to free it

--- a/src/alignment_writer.cpp
+++ b/src/alignment_writer.cpp
@@ -56,6 +56,7 @@ void parse_args(int argc, char* argv[], cxxargs::Arguments &args) {
   args.add_short_argument<size_t>('n', "Number of reference sequences in the pseudoalignment (required for packing).");
   args.add_short_argument<size_t>('r', "Number of reads in the pseudoalignment (required for packing).");
   args.add_long_argument<size_t>("buffer-size", "Buffer size for buffered packing (default: 100000", (size_t)100000);
+  args.add_long_argument<std::string>("format", "Input file format (one of `themisto` (default), `fulgor`)", "themisto");
   if (CmdOptionPresent(argv, argv+argc, "-d")) {
       args.set_not_required('r');
       args.set_not_required('n');
@@ -79,6 +80,15 @@ int main(int argc, char* argv[]) {
 	return 1;
     }
 
+    alignment_writer::Format format;
+    if (args.value<std::string>("format") == "themisto") {
+	format = alignment_writer::themisto;
+    } else if (args.value<std::string>("format") == "fulgor") {
+	format = alignment_writer::fulgor;
+    } else {
+	throw std::runtime_error("Unrecognized input format.");
+    }
+
     std::unique_ptr<std::istream> in;
     if (args.value<std::string>('f').empty()) {
 	in = std::unique_ptr<std::istream>(&std::cin);
@@ -90,7 +100,14 @@ int main(int argc, char* argv[]) {
     if (args.value<bool>('d')) {
 	alignment_writer::Print(in.get(), &std::cout);
     } else {
-        alignment_writer::BufferedPack(alignment_writer::themisto, args.value<size_t>('n'), args.value<size_t>('r'), args.value<size_t>("buffer-size"), in.get(), &std::cout);
+	try {
+	    alignment_writer::BufferedPack(format, args.value<size_t>('n'), args.value<size_t>('r'), args.value<size_t>("buffer-size"), in.get(), &std::cout);
+	} catch (const std::invalid_argument &e) {
+	    std::cerr << "Reading the alignment failed: " << e.what() << " (is `--format " << args.value<std::string>("format") << "` correct?)" << std::endl;
+	    return 1;
+	} catch (const std::exception &e) {
+	    std::cerr << "Reading the alignment failed: " << e.what() << '.' << std::endl;
+	}
     }
     if (args.value<std::string>('f').empty()) {
 	in.release(); // Release ownership of std::cout so we don't try to free it

--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -43,7 +43,7 @@
 namespace alignment_writer {
 void CheckInput(const size_t n_refs, const size_t n_reads) {
     size_t aln_size = (size_t)(n_reads * n_refs);
-    if (aln_size > (size_t)2^47) {
+    if (aln_size > (size_t)140737488355328) {
 	throw std::length_error("Input size exceeds maximum capacity (number of reads x number of references > 2^(48 - 1)).");
     }
 }

--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -35,11 +35,21 @@
 #include "pack.hpp"
 
 #include <sstream>
+#include <exception>
 
 #include "bm64.h"
 #include "bmserial.h"
 
 namespace alignment_writer {
+void CheckInput(const size_t n_refs, const size_t n_reads) {
+    size_t num_reads = args.value<size_t>('r');
+    size_t num_refs = args.value<size_t>('n');
+    size_t aln_size = (size_t)(num_reads * num_refs);
+    if (aln_size > (size_t)2^47) {
+	throw std::length_error("Input size exceeds maximum capacity (number of reads x number of references > 2^(48 - 1)).");
+    }
+}
+
 void WriteHeader(const size_t n_refs, const size_t n_reads, std::ostream *out) {
     // Write the header line of the packed format
     *out << n_reads << ',' << n_refs << '\n';
@@ -62,6 +72,7 @@ void WriteBuffer(const bm::bvector<> &bits, bm::serializer<bm::bvector<>> &bvs, 
 void BufferedPack(const size_t n_refs, const size_t n_reads, const size_t &buffer_size, std::istream *in, std::ostream *out) {
     // Buffered read + packing from a stream
     // Write info about the pseudoalignment
+    CheckInput(n_refs, n_reads);
     WriteHeader(n_refs, n_reads, out);
 
     // Next settings provide the lowest size (see BitMagic documentation/examples)
@@ -105,6 +116,7 @@ void BufferedPack(const size_t n_refs, const size_t n_reads, const size_t &buffe
 void Pack(const bm::bvector<> &bits, const size_t n_refs, const size_t n_reads, std::ostream *out) {
     // Pack a pseudoalignment that has been stored in memory
     // Write info about the pseudoalignment
+    CheckInput(n_refs, n_reads);
     WriteHeader(n_refs, n_reads, out);
 
     // Next settings provide the lowest size (see BitMagic documentation/examples)

--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -42,9 +42,7 @@
 
 namespace alignment_writer {
 void CheckInput(const size_t n_refs, const size_t n_reads) {
-    size_t num_reads = args.value<size_t>('r');
-    size_t num_refs = args.value<size_t>('n');
-    size_t aln_size = (size_t)(num_reads * num_refs);
+    size_t aln_size = (size_t)(n_reads * n_refs);
     if (aln_size > (size_t)2^47) {
 	throw std::length_error("Input size exceeds maximum capacity (number of reads x number of references > 2^(48 - 1)).");
     }

--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -84,6 +84,21 @@ size_t ThemistoParser(const std::string &line, const size_t n_refs, bm::bvector<
     return n_alignments;
 }
 
+size_t FulgorParser(const std::string &line, const size_t n_refs, bm::bvector<>::bulk_insert_iterator *it, size_t read_id) {
+    // Reads a pseudoalignment line stored in the *Fulgor* format and returns the number of pseudoalignments on the line
+    char separator = '\t';
+    std::stringstream stream(line);
+    std::string part;
+    std::getline(stream, part, separator); // First column is the fragment name
+    std::getline(stream, part, separator); // Second column is the number of alignments
+    size_t n_alignments = std::stoul(part);
+    while(std::getline(stream, part, separator)) {
+	// Buffered insertion to contiguously stored n_reads x n_refs pseudoalignment matrix
+	(*it) = read_id*n_refs + std::stoul(part);
+    }
+    return n_alignments;
+}
+
 void BufferedPack(const Format &format, const size_t n_refs, const size_t n_reads, const size_t &buffer_size, std::istream *in, std::ostream *out) {
     // Buffered read + packing from a stream
     // Write info about the pseudoalignment
@@ -102,6 +117,8 @@ void BufferedPack(const Format &format, const size_t n_refs, const size_t n_read
     std::function<size_t(const std::string &line, const size_t n_refs, bm::bvector<>::bulk_insert_iterator *it, size_t read_id)> parser;
     if (format == themisto) {
 	parser = ThemistoParser;
+    } else if (format == fulgor) {
+	parser = FulgorParser;
     } else {
 	throw std::runtime_error("Unrecognized input format.");
     }


### PR DESCRIPTION
- Add support for reading in alignment files from [Fulgor](https://github.com/jermp/fulgor) via the `--format fulgor` toggle (partially implements #2).
- Throw an error if input size exceeds 2^47 (max. size BitMagic can store).